### PR TITLE
Add basic CI workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,10 +48,12 @@ jobs:
       with:
         name: cake-darwin-amd64
         path: dist/cake-darwin-amd64
+
     - uses: actions/upload-artifact@v1
       with:
         name: cake-linux-amd64
         path: dist/cake-linux-amd64
+
     - uses: actions/upload-artifact@v1
       with:
         name: cake-windows.exe

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: CI Check
+name: go test and build
 
 on:
   push:
@@ -28,6 +28,11 @@ jobs:
             dep ensure
         fi
 
+    - name: goimports check
+      run: |
+        go get golang.org/x/tools/cmd/goimports
+        [[ -z "$(goimports -d -l ./pkg/cake)" ]] || exit 1
+
     - name: Run tests
       run: go test -v ./pkg/cake
 
@@ -46,5 +51,3 @@ jobs:
       with:
         name: cake-windows.exe
         path: dist/cake-windows.exe
-
-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    name: Build
+    name: build
     runs-on: ubuntu-latest
     steps:
     - name: Set up Go 1.13
@@ -28,10 +28,15 @@ jobs:
             dep ensure
         fi
 
-    - name: goimports check
+    - name: Run goimports check
       run: |
+        export PATH=${PATH}:$(go env GOPATH)/bin
         go get golang.org/x/tools/cmd/goimports
-        [[ -z "$(goimports -d -l ./pkg/cake)" ]] || exit 1
+        output=$(goimports -d -l -e ./pkg/cake)
+        if [[ ! -z "${output}" ]]; then
+          echo "${output}"
+          exit 1
+        fi
 
     - name: Run tests
       run: go test -v ./pkg/cake

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,50 @@
+name: CI Check
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+    - name: Set up Go 1.13
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.13
+      id: go
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+
+    - name: Get dependencies
+      run: |
+        go get -v -t -d ./...
+        if [ -f Gopkg.toml ]; then
+            curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+            dep ensure
+        fi
+
+    - name: Run tests
+      run: go test -v ./pkg/cake
+
+    - name: Build Go binaries
+      run: ./build.sh
+
+    - uses: actions/upload-artifact@v1
+      with:
+        name: cake-darwin-amd64
+        path: dist/cake-darwin-amd64
+    - uses: actions/upload-artifact@v1
+      with:
+        name: cake-linux-amd64
+        path: dist/cake-linux-amd64
+    - uses: actions/upload-artifact@v1
+      with:
+        name: cake-windows.exe
+        path: dist/cake-windows.exe
+
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /.idea/
 /cake
 /cake-*
+/dist

--- a/README.md
+++ b/README.md
@@ -111,7 +111,14 @@ To build the binary, run the following command from the project root:
 go build -i -o cake ./cmd/cake/main.go
 ```
 
-It will produce a binary compiled for the current OS/platform. Use `build.sh` to build for linux/amd64, darwin/amd64, and windows.
+It will produce a binary compiled for the current OS/platform. 
+
+Use `build.sh` to build for linux/amd64, darwin/amd64, and windows. 
+
+```
+./build.sh
+```
+This command will create a `dist` directory with all runnable binaries for each platform.
 
 To get a list of available options run:
 ```

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Cake Docker Builder
+![go test and build](https://github.com/mesosphere/cake-builder/workflows/go%20test%20and%20build/badge.svg)
 
 Cake Docker Builder is a tool for managing builds of Docker images organized in hierarchies (layers) in order to
 optimize build times, avoid code duplication, enforce deterministic builds, and support reuse of already defined

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -e
 platforms=("linux/amd64" "darwin/amd64" "windows")
+dist_dir="dist"
 
 for platform in "${platforms[@]}"
 do
@@ -15,5 +16,5 @@ do
     fi
 
     echo "Building for ${platform}: ${output_name}"
-    GOOS=${GOOS} GOARCH=${GOARCH} go build -o "${output_name}" ./cmd/cake/main.go
+    GOOS=${GOOS} GOARCH=${GOARCH} go build -o $dist_dir/"${output_name}" ./cmd/cake/main.go
 done

--- a/build.sh
+++ b/build.sh
@@ -16,5 +16,5 @@ do
     fi
 
     echo "Building for ${platform}: ${output_name}"
-    GOOS=${GOOS} GOARCH=${GOARCH} go build -o $dist_dir/"${output_name}" ./cmd/cake/main.go
+    GOOS=${GOOS} GOARCH=${GOARCH} go build -o ${dist_dir}/"${output_name}" ./cmd/cake/main.go
 done


### PR DESCRIPTION
This PR adds a basic CI check based on Github Actions for building, testing and publishing `cake-builder` binaries as build artifacts.

Signed-off-by: Alex Lembiewski <alembiyeuski.c@d2iq.com>