### PR TITLE
Adding global template properties support

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,20 @@ COPY shared/shared.sh /bin/shared.sh
 Check the [example](example) folder for a sample project layout.
 
 ### Configuration
+Cake configuration file has the following format:
+```
+# map of global properties used in all templates
+global_properties:
+  <property name>: <property value>
+
+# list of images in this build
+images:
+  - <image configration>
+  - <image configration>
+```
+Global properties are used by default in all the templates and can be overriden on a per-image basis. Properties
+defined in a specific image configuration take precedence over the global properties.
+
 The minimal image definition must contain the following properties:
 
 * `id` - a unique identifier of the image in this build
@@ -190,7 +204,10 @@ an image-specific `Dockerfile.template` is located are included by default)
 
 Example:
 ```
-build: 
+global_properties:
+  platform_version: 1.0.0
+
+images:
   - id: base-image
     repository: akirillov
     name: cake-example
@@ -208,6 +225,7 @@ build:
     extra_files:
       - shared
     properties:
+      platform_version: 1.0.1
       spark_version: 2.4.0
 ```
 

--- a/cmd/cake/main.go
+++ b/cmd/cake/main.go
@@ -34,14 +34,11 @@ func main() {
 	config.BaseDir = currentDir
 	config.ReleaseTag = *releaseTag
 	config.OutputFile = *outputFile
-
-	authConfig := cake.AuthConfig{
+	config.AuthConfig = cake.AuthConfig{
 		DockerRegistryUrl: *registryUrl,
 		Username:          *dockerUser,
 		Password:          *dockerPassword,
 	}
-
-	config.AuthConfig = authConfig
 
 	log.Println(config.Images)
 	log.Println(fmt.Sprintf("[build] dry run: %t, release tag: %s, output file: %s", *dryRun, *releaseTag, *outputFile))

--- a/example/.gitignore
+++ b/example/.gitignore
@@ -1,2 +1,2 @@
-Dockerfile
+./Dockerfile.generated
 /cake-report.json

--- a/example/base/Dockerfile.template
+++ b/example/base/Dockerfile.template
@@ -1,5 +1,7 @@
 FROM ubuntu:{{ubuntu_version}}
 
+LABEL version="{{version}}"
+
 ENV CONF_HOME /opt/config
 ENV TEST test_2
 RUN mkdir -p ${CONF_HOME}

--- a/example/cake.yaml
+++ b/example/cake.yaml
@@ -1,4 +1,9 @@
-build:
+global_properties:
+  # global property is used in all templates until there's
+  # an override in the image config
+  version: alpha
+
+images:
   - id: base-image
     repository: akirillov
     name: cake-example
@@ -26,3 +31,5 @@ build:
     template: child2/Dockerfile.template
     properties:
       cuda_version: 10.2
+      # overriding global property for this specific image
+      version: beta

--- a/example/child/Dockerfile.template
+++ b/example/child/Dockerfile.template
@@ -1,6 +1,9 @@
 FROM {{parent}}
 
+LABEL version="{{version}}"
+
 ENV TEST test
+
 COPY shared ${CONF_HOME}
 
 RUN echo "{{spark_version}}" > ${CONF_HOME}/version.txt

--- a/example/child2/Dockerfile.template
+++ b/example/child2/Dockerfile.template
@@ -1,7 +1,8 @@
 FROM {{parent}}
 
-ENV TEST test
+LABEL version="{{version}}"
 
+ENV TEST test
 ENV TEST2 test2
 
 COPY child2/start-gpu.sh ${CONF_HOME}/start-gpu.sh

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/mholt/archiver/v3 v3.3.0
 	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.0.1 // indirect
+	github.com/stretchr/testify v1.5.1
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0 // indirect
 	google.golang.org/grpc v1.28.0 // indirect
 	gopkg.in/yaml.v2 v2.2.8

--- a/go.sum
+++ b/go.sum
@@ -170,6 +170,8 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
+github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/timakin/bodyclose v0.0.0-20190721030226-87058b9bfcec/go.mod h1:Qimiffbc6q9tBWlVV6x0P9sat/ao1xEkREYPPj9hphk=
 github.com/ulikunitz/xz v0.5.6 h1:jGHAfXawEGZQ3blwU5wnWKQJvAraT7Ftq9EXjnXYgt8=
 github.com/ulikunitz/xz v0.5.6/go.mod h1:2bypXElzHzzJZwzH67Y6wb67pO62Rzfn7BSiF4ABRW8=

--- a/pkg/cake/config.go
+++ b/pkg/cake/config.go
@@ -35,11 +35,12 @@ type AuthConfig struct {
 }
 
 type BuildConfig struct {
-	AuthConfig AuthConfig
-	BaseDir    string
-	ReleaseTag string
-	OutputFile string
-	Images     []ImageConfig `yaml:"build"`
+	AuthConfig       AuthConfig
+	BaseDir          string
+	ReleaseTag       string
+	OutputFile       string
+	Images           []ImageConfig     `yaml:"images"`
+	GlobalProperties map[string]string `yaml:"global_properties"`
 }
 
 func (config BuildConfig) validate() error {

--- a/pkg/cake/config_test.go
+++ b/pkg/cake/config_test.go
@@ -1,0 +1,111 @@
+package cake
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLoadConfigFromFile(t *testing.T) {
+	config := `global_properties:
+  global_key_1: global_value_1
+  global_key_2: global_value_2
+
+images:
+  - id: base
+    repository: testorg
+    name: test
+    template: base/Dockerfile.template
+    tag_suffix: base
+    properties:
+      base_key_1: base_value_1
+      base_key_2: base_value_2
+    extra_files:
+      - base_file_1
+      - base_file_2
+
+  - id: child
+    parent: base
+    repository: testorg
+    name: test
+    template: child/Dockerfile.template
+    tag_suffix: child
+    properties:
+      child_key_1: child_value_1
+      child_key_2: child_value_2
+    extra_files:
+      - child_file_1
+      - child_file_2
+`
+
+	tmpDir, err := ioutil.TempDir("", "test")
+	if err != nil {
+		t.Errorf("Failed to create temporary directory: %v", err)
+	}
+	tmpFile, err := os.Create(path.Join(tmpDir, "cake.yaml"))
+	if err != nil {
+		t.Errorf("Failed to create file: %v", err)
+	}
+	_, err = tmpFile.Write([]byte(config))
+	if err != nil {
+		t.Errorf("Failed to write file: %v", err)
+	}
+
+	var buildConfig BuildConfig
+	err = buildConfig.LoadConfigFromFile(tmpFile.Name())
+	if err != nil {
+		t.Errorf("Failed to unmarshall file: %v", err)
+	}
+
+	assert.NotNil(t, buildConfig)
+	assert.NotNil(t, buildConfig.GlobalProperties)
+	assert.Equal(t, 2, len(buildConfig.GlobalProperties))
+	assert.Equal(t, "global_value_1", buildConfig.GlobalProperties["global_key_1"])
+	assert.Equal(t, "global_value_2", buildConfig.GlobalProperties["global_key_2"])
+
+	assert.NotNil(t, buildConfig.Images)
+	assert.Equal(t, 2, len(buildConfig.Images))
+
+	var base ImageConfig
+	var child ImageConfig
+
+	for _, image := range buildConfig.Images {
+		if image.Id == "base" {
+			base = image
+		}
+		if image.Id == "child" {
+			child = image
+		}
+	}
+	assert.NotNil(t, base)
+	assert.NotNil(t, child)
+
+	assert.Equal(t, "testorg", base.Repository)
+	assert.Equal(t, "test", base.Name)
+	assert.Equal(t, "base/Dockerfile.template", base.Template)
+	assert.Equal(t, "base", base.TagSuffix)
+
+	assert.Equal(t, 2, len(base.Properties))
+	assert.Equal(t, "base_value_1", base.Properties["base_key_1"])
+	assert.Equal(t, "base_value_2", base.Properties["base_key_2"])
+
+	assert.Equal(t, 2, len(base.ExtraFiles))
+	assert.Contains(t, base.ExtraFiles, "base_file_1")
+	assert.Contains(t, base.ExtraFiles, "base_file_2")
+
+	assert.Equal(t, "testorg", child.Repository)
+	assert.Equal(t, "test", child.Name)
+	assert.Equal(t, "child/Dockerfile.template", child.Template)
+	assert.Equal(t, "child", child.TagSuffix)
+
+	assert.Equal(t, 2, len(child.Properties))
+	assert.Equal(t, "child_value_1", child.Properties["child_key_1"])
+	assert.Equal(t, "child_value_2", child.Properties["child_key_2"])
+
+	assert.Equal(t, 2, len(child.ExtraFiles))
+	assert.Contains(t, child.ExtraFiles, "child_file_1")
+	assert.Contains(t, child.ExtraFiles, "child_file_2")
+}

--- a/pkg/cake/utils.go
+++ b/pkg/cake/utils.go
@@ -20,11 +20,18 @@ const GeneratedDockerFileNamePrefix = "Dockerfile.generated"
 func (image *Image) RenderDockerfileFromTemplate(config BuildConfig) error {
 	directory := filepath.Dir(image.ImageConfig.Template)
 
-	templateProperties := image.ImageConfig.Properties
+	templateProperties := config.GlobalProperties
 
-	if len(templateProperties) == 0 {
-		log.Printf("No properties provided for templating")
+	if templateProperties == nil {
 		templateProperties = make(map[string]string)
+	}
+
+	if len(image.ImageConfig.Properties) == 0 && len(templateProperties) == 0 {
+		log.Printf("No properties provided for templating")
+	} else {
+		for key, value := range image.ImageConfig.Properties {
+			templateProperties[key] = value
+		}
 	}
 
 	if image.Parent != nil {


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR adds global template properties support so that the same values can be reused in all the images with a possibility to override the defaults on a per-image basis. Example:
```
global_properties:
  tensorflow_version: 2.1.0

images:
   ...
  <parent images>
   ...
  - id: tensorflow-2.1.0
    parent: base
    repository: testorg
    name: test
    template: tensorflow/Dockerfile.template
    tag_suffix: tensorflow-2.1.0

  - id: tensorflow-1.15
    parent: base
    repository: testorg
    name: test
    template: tensorflow/Dockerfile.template
    tag_suffix: tensorflow-1.15
    properties:
      tensorflow_version: 1.15
```

This change comes especially handy when only leaf images require a change and based on the same Dockerfile template which leads to code duplication and the necessity to specify the same property for every image. Example:
```
build:
   ...
  <parent images>
   ...
  - id: notebook-tensorflow
    parent: tensorflow
    repository: testorg
    name: test
    template: jupyter/Dockerfile.template
    tag_suffix: jupyter-tensorflow
    properties:
      matplotlib_version: 1.3.1

  - id: notebook-pytorch
    parent: pytorch
    repository: testorg
    name: test
    template: jupyter/Dockerfile.template
    tag_suffix: jupyter-pytorch
    properties:
      matplotlib_version: 1.3.1
```
As you can see, `matplotlib_version` is specified twice in this example. With a significant number of properties and leaf images, the maintenance and upgrades of the properties becomes error-prone. After the change, a shared property needs to be specified only once and software version updates become a one-line change:
```
global_properties:
  matplotlib_version: 1.3.1

images:
   ...
  <parent images>
   ...
  - id: notebook-tensorflow
    parent: tensorflow
    repository: testorg
    name: test
    template: jupyter/Dockerfile.template
    tag_suffix: jupyter-tensorflow

  - id: notebook-pytorch
    parent: pytorch
    repository: testorg
    name: test
    template: jupyter/Dockerfile.template
    tag_suffix: jupyter-pytorch
```

**THIS IS A BREAKING CHANGE:** This PR changes the schema of configuration file and will not support the old format.

### How were the changes tested?
* by implementing additional unit tests for the new functionality
* go test and build from this repo