### PR TITLE
Add tags caching support to ExternalDockerClient

### DIFF
--- a/pkg/cake/docker_client_test.go
+++ b/pkg/cake/docker_client_test.go
@@ -22,7 +22,7 @@ type MockDockerClient struct {
 	ImagePushTags          []string
 }
 
-func (client *MockDockerClient) Tags(repository string, imageName string) (tags []string, err error) {
+func (client *MockDockerClient) Tags(imageName string) (tags []string, err error) {
 	return client.MockTagsResponse, nil
 }
 


### PR DESCRIPTION
This PR aims to reduce the number of HTTP calls made to the Docker registry while checking if an image with a specific tag exists. the main idea is to leverage tags cache, so the only one remote request needs to be executed and all the subsequent requests will get the results from the cache.

Signed-off-by: Alex Lembiewski <alembiyeuski.c@d2iq.com>